### PR TITLE
Avoid using MYSQL_ROOT_* env. variable on slaves

### DIFF
--- a/5.7/debian-9/rootfs/libmysql.sh
+++ b/5.7/debian-9/rootfs/libmysql.sh
@@ -271,9 +271,15 @@ EOF
             mysql_upgrade
         else
             info "Flushing privileges..."
-            mysql_execute "mysql" "$DB_ROOT_USER" "$DB_ROOT_PASSWORD" <<EOF
+            if  [ "$DB_REPLICATION_MODE" == "master" ]; then
+                mysql_execute "mysql" "$DB_ROOT_USER" "$DB_ROOT_PASSWORD" <<EOF
 flush privileges;
 EOF
+            else
+                mysql_execute "mysql" <<EOF
+flush privileges;
+EOF
+            fi
         fi
     fi
 }

--- a/5.7/ol-7/rootfs/libmysql.sh
+++ b/5.7/ol-7/rootfs/libmysql.sh
@@ -271,9 +271,15 @@ EOF
             mysql_upgrade
         else
             info "Flushing privileges..."
-            mysql_execute "mysql" "$DB_ROOT_USER" "$DB_ROOT_PASSWORD" <<EOF
+            if  [ "$DB_REPLICATION_MODE" == "master" ]; then
+                mysql_execute "mysql" "$DB_ROOT_USER" "$DB_ROOT_PASSWORD" <<EOF
 flush privileges;
 EOF
+            else
+                mysql_execute "mysql" <<EOF
+flush privileges;
+EOF
+            fi
         fi
     fi
 }

--- a/8.0/debian-9/rootfs/libmysql.sh
+++ b/8.0/debian-9/rootfs/libmysql.sh
@@ -271,9 +271,15 @@ EOF
             mysql_upgrade
         else
             info "Flushing privileges..."
-            mysql_execute "mysql" "$DB_ROOT_USER" "$DB_ROOT_PASSWORD" <<EOF
+            if  [ "$DB_REPLICATION_MODE" == "master" ]; then
+                mysql_execute "mysql" "$DB_ROOT_USER" "$DB_ROOT_PASSWORD" <<EOF
 flush privileges;
 EOF
+            else
+                mysql_execute "mysql" <<EOF
+flush privileges;
+EOF
+            fi
         fi
     fi
 }

--- a/8.0/ol-7/rootfs/libmysql.sh
+++ b/8.0/ol-7/rootfs/libmysql.sh
@@ -271,9 +271,15 @@ EOF
             mysql_upgrade
         else
             info "Flushing privileges..."
-            mysql_execute "mysql" "$DB_ROOT_USER" "$DB_ROOT_PASSWORD" <<EOF
+            if  [ "$DB_REPLICATION_MODE" == "master" ]; then
+                mysql_execute "mysql" "$DB_ROOT_USER" "$DB_ROOT_PASSWORD" <<EOF
 flush privileges;
 EOF
+            else
+                mysql_execute "mysql" <<EOF
+flush privileges;
+EOF
+            fi
         fi
     fi
 }


### PR DESCRIPTION
### What this PR does / why we need it:

Slaves should only use **MYSQL_MASTER_ROOT_XXX** env. variables instead of **MYSQL_MASTER_ROOT_XXX**.

We can find misconfigurations when setting both env vars.