### PR TITLE
Fix 'grants' command on databases with reserved names

### DIFF
--- a/5.7/debian-9/rootfs/libmysql.sh
+++ b/5.7/debian-9/rootfs/libmysql.sh
@@ -521,7 +521,7 @@ mysql_ensure_user_has_database_privileges() {
     local database="${2:?db is required}"
 
     mysql_execute "mysql" "$DB_ROOT_USER" "$DB_ROOT_PASSWORD" <<EOF
-grant all on $database.* to '$user'@'%';
+grant all on \`$database\`.* to '$user'@'%';
 EOF
 }
 

--- a/5.7/ol-7/rootfs/libmysql.sh
+++ b/5.7/ol-7/rootfs/libmysql.sh
@@ -521,7 +521,7 @@ mysql_ensure_user_has_database_privileges() {
     local database="${2:?db is required}"
 
     mysql_execute "mysql" "$DB_ROOT_USER" "$DB_ROOT_PASSWORD" <<EOF
-grant all on $database.* to '$user'@'%';
+grant all on \`$database\`.* to '$user'@'%';
 EOF
 }
 

--- a/8.0/debian-9/rootfs/libmysql.sh
+++ b/8.0/debian-9/rootfs/libmysql.sh
@@ -521,7 +521,7 @@ mysql_ensure_user_has_database_privileges() {
     local database="${2:?db is required}"
 
     mysql_execute "mysql" "$DB_ROOT_USER" "$DB_ROOT_PASSWORD" <<EOF
-grant all on $database.* to '$user'@'%';
+grant all on \`$database\`.* to '$user'@'%';
 EOF
 }
 

--- a/8.0/ol-7/rootfs/libmysql.sh
+++ b/8.0/ol-7/rootfs/libmysql.sh
@@ -521,7 +521,7 @@ mysql_ensure_user_has_database_privileges() {
     local database="${2:?db is required}"
 
     mysql_execute "mysql" "$DB_ROOT_USER" "$DB_ROOT_PASSWORD" <<EOF
-grant all on $database.* to '$user'@'%';
+grant all on \`$database\`.* to '$user'@'%';
 EOF
 }
 


### PR DESCRIPTION
### What this PR does / why we need it:
This PR fix the creation of databases when using certain name such as "default"