### PR TITLE
Ensure mysql unix socket file does not exist

### DIFF
--- a/5.7/debian-9/rootfs/setup.sh
+++ b/5.7/debian-9/rootfs/setup.sh
@@ -15,6 +15,8 @@ set -o pipefail
 # Load MySQL environment variables
 eval "$(mysql_env)"
 
+# Ensure mysql unix socket file does not exist
+rm -rf "$DB_TMP_DIR/mysql.sock.lock"
 # Ensure MySQL environment variables settings are valid
 mysql_validate
 # Ensure MySQL is stopped when this script ends.

--- a/5.7/ol-7/rootfs/setup.sh
+++ b/5.7/ol-7/rootfs/setup.sh
@@ -15,6 +15,8 @@ set -o pipefail
 # Load MySQL environment variables
 eval "$(mysql_env)"
 
+# Ensure mysql unix socket file does not exist
+rm -rf "$DB_TMP_DIR/mysql.sock.lock"
 # Ensure MySQL environment variables settings are valid
 mysql_validate
 # Ensure MySQL is stopped when this script ends.

--- a/8.0/debian-9/rootfs/setup.sh
+++ b/8.0/debian-9/rootfs/setup.sh
@@ -15,6 +15,8 @@ set -o pipefail
 # Load MySQL environment variables
 eval "$(mysql_env)"
 
+# Ensure mysql unix socket file does not exist
+rm -rf "$DB_TMP_DIR/mysql.sock.lock"
 # Ensure MySQL environment variables settings are valid
 mysql_validate
 # Ensure MySQL is stopped when this script ends.

--- a/8.0/ol-7/rootfs/setup.sh
+++ b/8.0/ol-7/rootfs/setup.sh
@@ -15,6 +15,8 @@ set -o pipefail
 # Load MySQL environment variables
 eval "$(mysql_env)"
 
+# Ensure mysql unix socket file does not exist
+rm -rf "$DB_TMP_DIR/mysql.sock.lock"
 # Ensure MySQL environment variables settings are valid
 mysql_validate
 # Ensure MySQL is stopped when this script ends.


### PR DESCRIPTION
It has been observed that on macOS Catalina the `mysql.sock.lock` file is not removed on shutdown (#80). The reason for this possibly could be dues to filesystem sync'ing. Under these circumstances, the server will not start due to the leftover lockfile.

To resolve this issue, we're now removing the lockfile when the container is launched.

**Applicable issues**

 - #80