### PR TITLE
modify cmd evaluation to accept args

### DIFF
--- a/5.7/debian-10/rootfs/opt/bitnami/scripts/mysql/entrypoint.sh
+++ b/5.7/debian-10/rootfs/opt/bitnami/scripts/mysql/entrypoint.sh
@@ -16,7 +16,7 @@ set -o pipefail
 
 print_welcome_page
 
-if [[ "$*" = "/opt/bitnami/scripts/mysql/run.sh" ]]; then
+if [[ "$1" = "/opt/bitnami/scripts/mysql/run.sh" ]]; then
     info "** Starting MySQL setup **"
     /opt/bitnami/scripts/mysql/setup.sh
     info "** MySQL setup finished! **"

--- a/8.0/debian-10/rootfs/opt/bitnami/scripts/mysql/entrypoint.sh
+++ b/8.0/debian-10/rootfs/opt/bitnami/scripts/mysql/entrypoint.sh
@@ -16,7 +16,7 @@ set -o pipefail
 
 print_welcome_page
 
-if [[ "$*" = "/opt/bitnami/scripts/mysql/run.sh" ]]; then
+if [[ "$1" = "/opt/bitnami/scripts/mysql/run.sh" ]]; then
     info "** Starting MySQL setup **"
     /opt/bitnami/scripts/mysql/setup.sh
     info "** MySQL setup finished! **"


### PR DESCRIPTION
**Description of the change**

When we use docker CMD as args for the `entrypoint.sh` we cannot accept arguments because of this evaluation

```bash
[[ "$*" = "/opt/bitnami/scripts/mariadb/run.sh" ]]
```

```bahs
[[ "/opt/bitnami/scripts/mariadb/run.sh --super-read-only=1" = "/opt/bitnami/scripts/mariadb/run.sh" ]]
```

so the script is going to skip `/opt/bitnami/scripts/mariadb/setup.sh` and will fail.

Evaluating just the first argument of the `entrypoint.sh` is `run.sh` is enough to not skip `setup.sh`

**Benefits**

We can use CMD as args for the `entrypoint.sh`

**Possible drawbacks**

N/A

**Applicable issues**

- fixes #102

**Additional information**

N/A
