### PR TITLE
Improve mysql_stop to ensure db files are unlocked

### DIFF
--- a/5.7/debian-10/Dockerfile
+++ b/5.7/debian-10/Dockerfile
@@ -8,7 +8,7 @@ ENV HOME="/" \
 
 COPY prebuildfs /
 # Install required system packages and dependencies
-RUN install_packages acl ca-certificates curl gzip libaio1 libatomic1 libc6 libgcc1 libncurses6 libsasl2-2 libssl1.1 libstdc++6 libtinfo6 procps tar
+RUN install_packages acl ca-certificates curl gzip libaio1 libatomic1 libc6 libgcc1 libncurses6 libsasl2-2 libssl1.1 libstdc++6 libtinfo6 procps tar lsof
 RUN . /opt/bitnami/scripts/libcomponent.sh && component_unpack "ini-file" "1.3.0-2" --checksum d89528e5d733f34ae030984584659ff10a36370d40332bd8d41c047764d39cda
 RUN . /opt/bitnami/scripts/libcomponent.sh && component_unpack "mysql" "5.7.34-0" --checksum 683470d9dac8b7120f05b703abe3eebb83fc84655c81037307fea69718187352
 RUN . /opt/bitnami/scripts/libcomponent.sh && component_unpack "gosu" "1.12.0-2" --checksum 4d858ac600c38af8de454c27b7f65c0074ec3069880cb16d259a6e40a46bbc50

--- a/5.7/debian-10/rootfs/opt/bitnami/scripts/libmysql.sh
+++ b/5.7/debian-10/rootfs/opt/bitnami/scripts/libmysql.sh
@@ -668,10 +668,26 @@ wait_for_mysql_access() {
 #   None
 #########################
 mysql_stop() {
-    ! is_mysql_running && return
+    local -r retries=25
+    local -r sleep_time=5
+
+    are_db_files_locked() {
+        local return_value=0
+        for f in "ibdata1" "ib_logfile0" "ib_logfile1"; do
+            debug_execute lsof -w "${DB_DATA_DIR}/${f}" && return_value=1
+        done
+        return $return_value
+    }
+
+    is_mysql_not_running && return
 
     info "Stopping $DB_FLAVOR"
     stop_service_using_pid "$DB_PID_FILE"
+    debug "Waiting for $DB_FLAVOR to unlock db files"
+    if ! retry_while are_db_files_locked "$retries" "$sleep_time"; then
+        error "MySQL failed to stop"
+        return 1
+    fi
 }
 
 ########################

--- a/5.7/debian-10/rootfs/opt/bitnami/scripts/libmysql.sh
+++ b/5.7/debian-10/rootfs/opt/bitnami/scripts/libmysql.sh
@@ -673,8 +673,9 @@ mysql_stop() {
 
     are_db_files_locked() {
         local return_value=0
-        for f in "ibdata1" "ib_logfile0" "ib_logfile1"; do
-            debug_execute lsof -w "${DB_DATA_DIR}/${f}" && return_value=1
+        read -r -a db_files <<< "$(find "$DB_DATA_DIR" -regex "^.*ibdata[0-9]+" -o -regex "^.*ib_logfile[0-9]+" | xargs)"
+        for f in "${db_files[@]}"; do
+            debug_execute lsof -w "$f" && return_value=1
         done
         return $return_value
     }

--- a/8.0/debian-10/Dockerfile
+++ b/8.0/debian-10/Dockerfile
@@ -8,7 +8,7 @@ ENV HOME="/" \
 
 COPY prebuildfs /
 # Install required system packages and dependencies
-RUN install_packages acl ca-certificates curl gzip libaio1 libc6 libcom-err2 libgcc1 libk5crypto3 libkeyutils1 libkrb5-3 libkrb5support0 libncurses6 libsasl2-2 libssl1.1 libstdc++6 libtinfo6 procps tar
+RUN install_packages acl ca-certificates curl gzip libaio1 libc6 libcom-err2 libgcc1 libk5crypto3 libkeyutils1 libkrb5-3 libkrb5support0 libncurses6 libsasl2-2 libssl1.1 libstdc++6 libtinfo6 procps tar lsof
 RUN . /opt/bitnami/scripts/libcomponent.sh && component_unpack "ini-file" "1.3.0-2" --checksum d89528e5d733f34ae030984584659ff10a36370d40332bd8d41c047764d39cda
 RUN . /opt/bitnami/scripts/libcomponent.sh && component_unpack "mysql" "8.0.25-0" --checksum ac2aa9081eb14b51a897da6250a534e680c59bf472a3b46d59fa09a6e1f5baca
 RUN . /opt/bitnami/scripts/libcomponent.sh && component_unpack "gosu" "1.12.0-2" --checksum 4d858ac600c38af8de454c27b7f65c0074ec3069880cb16d259a6e40a46bbc50

--- a/8.0/debian-10/rootfs/opt/bitnami/scripts/libmysql.sh
+++ b/8.0/debian-10/rootfs/opt/bitnami/scripts/libmysql.sh
@@ -668,10 +668,26 @@ wait_for_mysql_access() {
 #   None
 #########################
 mysql_stop() {
-    ! is_mysql_running && return
+    local -r retries=25
+    local -r sleep_time=5
+
+    are_db_files_locked() {
+        local return_value=0
+        for f in "ibdata1" "ib_logfile0" "ib_logfile1"; do
+            debug_execute lsof -w "${DB_DATA_DIR}/${f}" && return_value=1
+        done
+        return $return_value
+    }
+
+    is_mysql_not_running && return
 
     info "Stopping $DB_FLAVOR"
     stop_service_using_pid "$DB_PID_FILE"
+    debug "Waiting for $DB_FLAVOR to unlock db files"
+    if ! retry_while are_db_files_locked "$retries" "$sleep_time"; then
+        error "MySQL failed to stop"
+        return 1
+    fi
 }
 
 ########################

--- a/8.0/debian-10/rootfs/opt/bitnami/scripts/libmysql.sh
+++ b/8.0/debian-10/rootfs/opt/bitnami/scripts/libmysql.sh
@@ -673,8 +673,9 @@ mysql_stop() {
 
     are_db_files_locked() {
         local return_value=0
-        for f in "ibdata1" "ib_logfile0" "ib_logfile1"; do
-            debug_execute lsof -w "${DB_DATA_DIR}/${f}" && return_value=1
+        read -r -a db_files <<< "$(find "$DB_DATA_DIR" -regex "^.*ibdata[0-9]+" -o -regex "^.*ib_logfile[0-9]+" | xargs)"
+        for f in "${db_files[@]}"; do
+            debug_execute lsof -w "$f" && return_value=1
         done
         return $return_value
     }


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

This PR attempts to improve the reliability of the `mysql_stop` function by ensuring the db files are unlocked after they MySQL process is stopped.

We observed that sometimes MySQL failed during the container initialization with the error below:

```console
Unable to lock ./ibdata1 error: 11
```

We do a "restart" of MySQL during the container setup, and it seems that sometimes the db files are not liberated simultaneously with the kill of the process.

**Benefits**

Reliability

**Possible drawbacks**

None

**Applicable issues**

- fixes https://github.com/bitnami/bitnami-docker-mysql/issues/129

**Additional information**

None
