### PR TITLE
Adding docker-entrypoint-startdb.d

### DIFF
--- a/5.7/debian-10/Dockerfile
+++ b/5.7/debian-10/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update && apt-get upgrade -y && \
     rm -r /var/lib/apt/lists /var/cache/apt/archives
 RUN chmod g+rwX /opt/bitnami
 RUN mkdir /docker-entrypoint-initdb.d
+RUN mkdir /docker-entrypoint-startdb.d
 
 COPY rootfs /
 RUN /opt/bitnami/scripts/mysql/postunpack.sh

--- a/5.7/debian-10/Dockerfile
+++ b/5.7/debian-10/Dockerfile
@@ -21,7 +21,7 @@ RUN mkdir /docker-entrypoint-startdb.d
 COPY rootfs /
 RUN /opt/bitnami/scripts/mysql/postunpack.sh
 ENV BITNAMI_APP_NAME="mysql" \
-    BITNAMI_IMAGE_VERSION="5.7.37-debian-10-r50" \
+    BITNAMI_IMAGE_VERSION="5.7.37-debian-10-r51" \
     PATH="/opt/bitnami/common/bin:/opt/bitnami/mysql/bin:/opt/bitnami/mysql/sbin:$PATH"
 
 EXPOSE 3306

--- a/5.7/debian-10/Dockerfile
+++ b/5.7/debian-10/Dockerfile
@@ -21,7 +21,7 @@ RUN mkdir /docker-entrypoint-startdb.d
 COPY rootfs /
 RUN /opt/bitnami/scripts/mysql/postunpack.sh
 ENV BITNAMI_APP_NAME="mysql" \
-    BITNAMI_IMAGE_VERSION="5.7.37-debian-10-r49" \
+    BITNAMI_IMAGE_VERSION="5.7.37-debian-10-r50" \
     PATH="/opt/bitnami/common/bin:/opt/bitnami/mysql/bin:/opt/bitnami/mysql/sbin:$PATH"
 
 EXPOSE 3306

--- a/5.7/debian-10/Dockerfile
+++ b/5.7/debian-10/Dockerfile
@@ -21,7 +21,7 @@ RUN mkdir /docker-entrypoint-startdb.d
 COPY rootfs /
 RUN /opt/bitnami/scripts/mysql/postunpack.sh
 ENV BITNAMI_APP_NAME="mysql" \
-    BITNAMI_IMAGE_VERSION="5.7.37-debian-10-r55" \
+    BITNAMI_IMAGE_VERSION="5.7.37-debian-10-r56" \
     PATH="/opt/bitnami/common/bin:/opt/bitnami/mysql/bin:/opt/bitnami/mysql/sbin:$PATH"
 
 EXPOSE 3306

--- a/5.7/debian-10/Dockerfile
+++ b/5.7/debian-10/Dockerfile
@@ -21,7 +21,7 @@ RUN mkdir /docker-entrypoint-startdb.d
 COPY rootfs /
 RUN /opt/bitnami/scripts/mysql/postunpack.sh
 ENV BITNAMI_APP_NAME="mysql" \
-    BITNAMI_IMAGE_VERSION="5.7.37-debian-10-r53" \
+    BITNAMI_IMAGE_VERSION="5.7.37-debian-10-r54" \
     PATH="/opt/bitnami/common/bin:/opt/bitnami/mysql/bin:/opt/bitnami/mysql/sbin:$PATH"
 
 EXPOSE 3306

--- a/5.7/debian-10/Dockerfile
+++ b/5.7/debian-10/Dockerfile
@@ -21,7 +21,7 @@ RUN mkdir /docker-entrypoint-startdb.d
 COPY rootfs /
 RUN /opt/bitnami/scripts/mysql/postunpack.sh
 ENV BITNAMI_APP_NAME="mysql" \
-    BITNAMI_IMAGE_VERSION="5.7.37-debian-10-r51" \
+    BITNAMI_IMAGE_VERSION="5.7.37-debian-10-r52" \
     PATH="/opt/bitnami/common/bin:/opt/bitnami/mysql/bin:/opt/bitnami/mysql/sbin:$PATH"
 
 EXPOSE 3306

--- a/5.7/debian-10/Dockerfile
+++ b/5.7/debian-10/Dockerfile
@@ -21,7 +21,7 @@ RUN mkdir /docker-entrypoint-startdb.d
 COPY rootfs /
 RUN /opt/bitnami/scripts/mysql/postunpack.sh
 ENV BITNAMI_APP_NAME="mysql" \
-    BITNAMI_IMAGE_VERSION="5.7.37-debian-10-r52" \
+    BITNAMI_IMAGE_VERSION="5.7.37-debian-10-r53" \
     PATH="/opt/bitnami/common/bin:/opt/bitnami/mysql/bin:/opt/bitnami/mysql/sbin:$PATH"
 
 EXPOSE 3306

--- a/5.7/debian-10/Dockerfile
+++ b/5.7/debian-10/Dockerfile
@@ -21,7 +21,7 @@ RUN mkdir /docker-entrypoint-startdb.d
 COPY rootfs /
 RUN /opt/bitnami/scripts/mysql/postunpack.sh
 ENV BITNAMI_APP_NAME="mysql" \
-    BITNAMI_IMAGE_VERSION="5.7.37-debian-10-r54" \
+    BITNAMI_IMAGE_VERSION="5.7.37-debian-10-r55" \
     PATH="/opt/bitnami/common/bin:/opt/bitnami/mysql/bin:/opt/bitnami/mysql/sbin:$PATH"
 
 EXPOSE 3306

--- a/5.7/debian-10/rootfs/opt/bitnami/scripts/libmysql.sh
+++ b/5.7/debian-10/rootfs/opt/bitnami/scripts/libmysql.sh
@@ -321,7 +321,6 @@ EOF
     fi
 }
 
-
 ########################
 # Run custom scripts
 # Globals:

--- a/5.7/debian-10/rootfs/opt/bitnami/scripts/libmysql.sh
+++ b/5.7/debian-10/rootfs/opt/bitnami/scripts/libmysql.sh
@@ -384,7 +384,7 @@ mysql_custom_init_scripts() {
 # Returns:
 #   None
 #########################
-mysql_custom_init_scripts() {
+mysql_custom_start_scripts() {
     if [[ -n $(find /docker-entrypoint-startdb.d/ -type f -regex ".*\.\(sh\|sql\|sql.gz\)") ]] ; then
         info "Loading user's custom files from /docker-entrypoint-startdb.d";
         for f in /docker-entrypoint-startdb.d/*; do

--- a/5.7/debian-10/rootfs/opt/bitnami/scripts/libmysql.sh
+++ b/5.7/debian-10/rootfs/opt/bitnami/scripts/libmysql.sh
@@ -376,6 +376,59 @@ mysql_custom_init_scripts() {
 }
 
 ########################
+# Run custom start scripts
+# Globals:
+#   DB_*
+# Arguments:
+#   None
+# Returns:
+#   None
+#########################
+mysql_custom_init_scripts() {
+    if [[ -n $(find /docker-entrypoint-startdb.d/ -type f -regex ".*\.\(sh\|sql\|sql.gz\)") ]] ; then
+        info "Loading user's custom files from /docker-entrypoint-startdb.d";
+        for f in /docker-entrypoint-startdb.d/*; do
+            debug "Executing $f"
+            case "$f" in
+                *.sh)
+                    if [[ -x "$f" ]]; then
+                        if ! "$f"; then
+                            error "Failed executing $f"
+                            return 1
+                        fi
+                    else
+                        warn "Sourcing $f as it is not executable by the current user, any error may cause initialization to fail"
+                        . "$f"
+                    fi
+                    ;;
+                *.sql)
+                    [[ "$DB_REPLICATION_MODE" = "slave" ]] && warn "Custom SQL startdb is not supported on slave nodes, ignoring $f" && continue
+                    wait_for_mysql_access "$DB_ROOT_USER"
+                    # Temporarily disabling autocommit to increase performance when importing huge files
+                    if ! mysql_execute_print_output "$DB_DATABASE" "$DB_ROOT_USER" "$DB_ROOT_PASSWORD" <<< "SET autocommit=0; source ${f}; COMMIT;"; then
+                        error "Failed executing $f"
+                        return 1
+                    fi
+                    ;;
+                *.sql.gz)
+                    [[ "$DB_REPLICATION_MODE" = "slave" ]] && warn "Custom SQL startdb is not supported on slave nodes, ignoring $f" && continue
+                    wait_for_mysql_access "$DB_ROOT_USER"
+                    # In this case, it is best to pipe the uncompressed SQL commands directly to the 'mysql' command as extraction may cause problems
+                    # e.g. lack of disk space, permission issues...
+                    if ! gunzip -c "$f" | mysql_execute_print_output "$DB_DATABASE" "$DB_ROOT_USER" "$DB_ROOT_PASSWORD"; then
+                        error "Failed executing $f"
+                        return 1
+                    fi
+                    ;;
+                *)
+                    warn "Skipping $f, supported formats are: .sh .sql .sql.gz"
+                    ;;
+            esac
+        done
+    fi
+}
+
+########################
 # Starts MySQL/MariaDB in the background and waits until it's ready
 # Globals:
 #   DB_*

--- a/5.7/debian-10/rootfs/opt/bitnami/scripts/libmysql.sh
+++ b/5.7/debian-10/rootfs/opt/bitnami/scripts/libmysql.sh
@@ -332,9 +332,9 @@ EOF
 #   None
 #########################
 mysql_custom_scripts() {
-    if [[ -n $(find /docker-entrypoint-initdb.d/ -type f -regex ".*\.\(sh\|sql\|sql.gz\)") ]] && \
-    ([[ ! -f "$DB_DATA_DIR/.user_scripts_initialized" ]] || $1 == 'start'); then
-        info "Loading user's custom files from /docker-entrypoint-initdb.d";
+    if [[ -n $(find /docker-entrypoint-$1db.d/ -type f -regex ".*\.\(sh\|sql\|sql.gz\)") ]] && \
+      ([[ ! -f "$DB_DATA_DIR/.user_scripts_initialized" ]] || $1 == 'start'); then
+        info "Loading user's custom files from /docker-entrypoint-$1db.d";
         for f in /docker-entrypoint-$1db.d/*; do
             debug "Executing $f"
             case "$f" in
@@ -350,7 +350,7 @@ mysql_custom_scripts() {
                     fi
                     ;;
                 *.sql)
-                    [[ "$DB_REPLICATION_MODE" = "slave" ]] && warn "Custom SQL initdb is not supported on slave nodes, ignoring $f" && continue
+                    [[ "$DB_REPLICATION_MODE" = "slave" ]] && warn "Custom SQL $1db is not supported on slave nodes, ignoring $f" && continue
                     wait_for_mysql_access "$DB_ROOT_USER"
                     # Temporarily disabling autocommit to increase performance when importing huge files
                     if ! mysql_execute_print_output "$DB_DATABASE" "$DB_ROOT_USER" "$DB_ROOT_PASSWORD" <<< "SET autocommit=0; source ${f}; COMMIT;"; then
@@ -359,7 +359,7 @@ mysql_custom_scripts() {
                     fi
                     ;;
                 *.sql.gz)
-                    [[ "$DB_REPLICATION_MODE" = "slave" ]] && warn "Custom SQL initdb is not supported on slave nodes, ignoring $f" && continue
+                    [[ "$DB_REPLICATION_MODE" = "slave" ]] && warn "Custom SQL $1db is not supported on slave nodes, ignoring $f" && continue
                     wait_for_mysql_access "$DB_ROOT_USER"
                     # In this case, it is best to pipe the uncompressed SQL commands directly to the 'mysql' command as extraction may cause problems
                     # e.g. lack of disk space, permission issues...

--- a/5.7/debian-10/rootfs/opt/bitnami/scripts/libmysql.sh
+++ b/5.7/debian-10/rootfs/opt/bitnami/scripts/libmysql.sh
@@ -321,19 +321,21 @@ EOF
     fi
 }
 
+
 ########################
-# Run custom initialization scripts
+# Run custom scripts
 # Globals:
 #   DB_*
-# Arguments:
-#   None
+# Arguments: 
+#   $1 - 'init' or 'start' ('init' runs on first container start, 'start' runs everytime the container starts)
 # Returns:
 #   None
 #########################
-mysql_custom_init_scripts() {
-    if [[ -n $(find /docker-entrypoint-initdb.d/ -type f -regex ".*\.\(sh\|sql\|sql.gz\)") ]] && [[ ! -f "$DB_DATA_DIR/.user_scripts_initialized" ]] ; then
+mysql_custom_scripts() {
+    if [[ -n $(find /docker-entrypoint-initdb.d/ -type f -regex ".*\.\(sh\|sql\|sql.gz\)") ]] && \
+    ([[ ! -f "$DB_DATA_DIR/.user_scripts_initialized" ]] || $1 == 'start'); then
         info "Loading user's custom files from /docker-entrypoint-initdb.d";
-        for f in /docker-entrypoint-initdb.d/*; do
+        for f in /docker-entrypoint-$1db.d/*; do
             debug "Executing $f"
             case "$f" in
                 *.sh)
@@ -372,59 +374,6 @@ mysql_custom_init_scripts() {
             esac
         done
         touch "$DB_DATA_DIR"/.user_scripts_initialized
-    fi
-}
-
-########################
-# Run custom start scripts
-# Globals:
-#   DB_*
-# Arguments:
-#   None
-# Returns:
-#   None
-#########################
-mysql_custom_start_scripts() {
-    if [[ -n $(find /docker-entrypoint-startdb.d/ -type f -regex ".*\.\(sh\|sql\|sql.gz\)") ]] ; then
-        info "Loading user's custom files from /docker-entrypoint-startdb.d";
-        for f in /docker-entrypoint-startdb.d/*; do
-            debug "Executing $f"
-            case "$f" in
-                *.sh)
-                    if [[ -x "$f" ]]; then
-                        if ! "$f"; then
-                            error "Failed executing $f"
-                            return 1
-                        fi
-                    else
-                        warn "Sourcing $f as it is not executable by the current user, any error may cause initialization to fail"
-                        . "$f"
-                    fi
-                    ;;
-                *.sql)
-                    [[ "$DB_REPLICATION_MODE" = "slave" ]] && warn "Custom SQL startdb is not supported on slave nodes, ignoring $f" && continue
-                    wait_for_mysql_access "$DB_ROOT_USER"
-                    # Temporarily disabling autocommit to increase performance when importing huge files
-                    if ! mysql_execute_print_output "$DB_DATABASE" "$DB_ROOT_USER" "$DB_ROOT_PASSWORD" <<< "SET autocommit=0; source ${f}; COMMIT;"; then
-                        error "Failed executing $f"
-                        return 1
-                    fi
-                    ;;
-                *.sql.gz)
-                    [[ "$DB_REPLICATION_MODE" = "slave" ]] && warn "Custom SQL startdb is not supported on slave nodes, ignoring $f" && continue
-                    wait_for_mysql_access "$DB_ROOT_USER"
-                    # In this case, it is best to pipe the uncompressed SQL commands directly to the 'mysql' command as extraction may cause problems
-                    # e.g. lack of disk space, permission issues...
-                    if ! gunzip -c "$f" | mysql_execute_print_output "$DB_DATABASE" "$DB_ROOT_USER" "$DB_ROOT_PASSWORD"; then
-                        error "Failed executing $f"
-                        return 1
-                    fi
-                    ;;
-                *)
-                    warn "Skipping $f, supported formats are: .sh .sql .sql.gz"
-                    ;;
-            esac
-        done
     fi
 }
 

--- a/5.7/debian-10/rootfs/opt/bitnami/scripts/libmysql.sh
+++ b/5.7/debian-10/rootfs/opt/bitnami/scripts/libmysql.sh
@@ -331,8 +331,7 @@ EOF
 #   None
 #########################
 mysql_custom_scripts() {
-    if [[ -n $(find /docker-entrypoint-$1db.d/ -type f -regex ".*\.\(sh\|sql\|sql.gz\)") ]] && \
-      ([[ ! -f "$DB_DATA_DIR/.user_scripts_initialized" ]] || $1 == 'start'); then
+    if [[ -n $(find /docker-entrypoint-"$1"db.d/ -type f -regex ".*\.\(sh\|sql\|sql.gz\)") ]] && { [[ ! -f "$DB_DATA_DIR/.user_scripts_initialized" ]] || [[ $1 = start ]]; } then
         info "Loading user's custom files from /docker-entrypoint-$1db.d";
         for f in /docker-entrypoint-$1db.d/*; do
             debug "Executing $f"

--- a/5.7/debian-10/rootfs/opt/bitnami/scripts/libmysql.sh
+++ b/5.7/debian-10/rootfs/opt/bitnami/scripts/libmysql.sh
@@ -333,7 +333,7 @@ EOF
 mysql_custom_scripts() {
     if [[ -n $(find /docker-entrypoint-"$1"db.d/ -type f -regex ".*\.\(sh\|sql\|sql.gz\)") ]] && { [[ ! -f "$DB_DATA_DIR/.user_scripts_initialized" ]] || [[ $1 = start ]]; } then
         info "Loading user's custom files from /docker-entrypoint-$1db.d";
-        for f in /docker-entrypoint-$1db.d/*; do
+        for f in /docker-entrypoint-"$1"db.d/*; do
             debug "Executing $f"
             case "$f" in
                 *.sh)

--- a/5.7/debian-10/rootfs/opt/bitnami/scripts/libmysql.sh
+++ b/5.7/debian-10/rootfs/opt/bitnami/scripts/libmysql.sh
@@ -326,7 +326,7 @@ EOF
 # Run custom scripts
 # Globals:
 #   DB_*
-# Arguments: 
+# Arguments:
 #   $1 - 'init' or 'start' ('init' runs on first container start, 'start' runs everytime the container starts)
 # Returns:
 #   None

--- a/5.7/debian-10/rootfs/opt/bitnami/scripts/mysql/setup.sh
+++ b/5.7/debian-10/rootfs/opt/bitnami/scripts/mysql/setup.sh
@@ -31,6 +31,8 @@ fi
 mysql_initialize
 # Allow running custom initialization scripts
 mysql_custom_init_scripts
+# Allow running custom start scripts
+mysql_custom_start_scripts
 # Stop MySQL before flagging it as fully initialized.
 # Relying only on the trap defined above could produce a race condition.
 mysql_stop

--- a/5.7/debian-10/rootfs/opt/bitnami/scripts/mysql/setup.sh
+++ b/5.7/debian-10/rootfs/opt/bitnami/scripts/mysql/setup.sh
@@ -30,9 +30,9 @@ fi
 # Ensure MySQL is initialized
 mysql_initialize
 # Allow running custom initialization scripts
-mysql_custom_init_scripts
+mysql_custom_scripts 'init'
 # Allow running custom start scripts
-mysql_custom_start_scripts
+mysql_custom_scripts 'start'
 # Stop MySQL before flagging it as fully initialized.
 # Relying only on the trap defined above could produce a race condition.
 mysql_stop

--- a/8.0/debian-10/Dockerfile
+++ b/8.0/debian-10/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update && apt-get upgrade -y && \
     rm -r /var/lib/apt/lists /var/cache/apt/archives
 RUN chmod g+rwX /opt/bitnami
 RUN mkdir /docker-entrypoint-initdb.d
+RUN mkdir /docker-entrypoint-startdb.d
 
 COPY rootfs /
 RUN /opt/bitnami/scripts/mysql/postunpack.sh

--- a/8.0/debian-10/Dockerfile
+++ b/8.0/debian-10/Dockerfile
@@ -21,7 +21,7 @@ RUN mkdir /docker-entrypoint-startdb.d
 COPY rootfs /
 RUN /opt/bitnami/scripts/mysql/postunpack.sh
 ENV BITNAMI_APP_NAME="mysql" \
-    BITNAMI_IMAGE_VERSION="8.0.28-debian-10-r36" \
+    BITNAMI_IMAGE_VERSION="8.0.28-debian-10-r37" \
     PATH="/opt/bitnami/common/bin:/opt/bitnami/mysql/bin:/opt/bitnami/mysql/sbin:$PATH"
 
 EXPOSE 3306

--- a/8.0/debian-10/Dockerfile
+++ b/8.0/debian-10/Dockerfile
@@ -21,7 +21,7 @@ RUN mkdir /docker-entrypoint-startdb.d
 COPY rootfs /
 RUN /opt/bitnami/scripts/mysql/postunpack.sh
 ENV BITNAMI_APP_NAME="mysql" \
-    BITNAMI_IMAGE_VERSION="8.0.28-debian-10-r35" \
+    BITNAMI_IMAGE_VERSION="8.0.28-debian-10-r36" \
     PATH="/opt/bitnami/common/bin:/opt/bitnami/mysql/bin:/opt/bitnami/mysql/sbin:$PATH"
 
 EXPOSE 3306

--- a/8.0/debian-10/Dockerfile
+++ b/8.0/debian-10/Dockerfile
@@ -21,7 +21,7 @@ RUN mkdir /docker-entrypoint-startdb.d
 COPY rootfs /
 RUN /opt/bitnami/scripts/mysql/postunpack.sh
 ENV BITNAMI_APP_NAME="mysql" \
-    BITNAMI_IMAGE_VERSION="8.0.28-debian-10-r39" \
+    BITNAMI_IMAGE_VERSION="8.0.28-debian-10-r40" \
     PATH="/opt/bitnami/common/bin:/opt/bitnami/mysql/bin:/opt/bitnami/mysql/sbin:$PATH"
 
 EXPOSE 3306

--- a/8.0/debian-10/Dockerfile
+++ b/8.0/debian-10/Dockerfile
@@ -21,7 +21,7 @@ RUN mkdir /docker-entrypoint-startdb.d
 COPY rootfs /
 RUN /opt/bitnami/scripts/mysql/postunpack.sh
 ENV BITNAMI_APP_NAME="mysql" \
-    BITNAMI_IMAGE_VERSION="8.0.28-debian-10-r34" \
+    BITNAMI_IMAGE_VERSION="8.0.28-debian-10-r35" \
     PATH="/opt/bitnami/common/bin:/opt/bitnami/mysql/bin:/opt/bitnami/mysql/sbin:$PATH"
 
 EXPOSE 3306

--- a/8.0/debian-10/Dockerfile
+++ b/8.0/debian-10/Dockerfile
@@ -21,7 +21,7 @@ RUN mkdir /docker-entrypoint-startdb.d
 COPY rootfs /
 RUN /opt/bitnami/scripts/mysql/postunpack.sh
 ENV BITNAMI_APP_NAME="mysql" \
-    BITNAMI_IMAGE_VERSION="8.0.28-debian-10-r33" \
+    BITNAMI_IMAGE_VERSION="8.0.28-debian-10-r34" \
     PATH="/opt/bitnami/common/bin:/opt/bitnami/mysql/bin:/opt/bitnami/mysql/sbin:$PATH"
 
 EXPOSE 3306

--- a/8.0/debian-10/Dockerfile
+++ b/8.0/debian-10/Dockerfile
@@ -21,7 +21,7 @@ RUN mkdir /docker-entrypoint-startdb.d
 COPY rootfs /
 RUN /opt/bitnami/scripts/mysql/postunpack.sh
 ENV BITNAMI_APP_NAME="mysql" \
-    BITNAMI_IMAGE_VERSION="8.0.28-debian-10-r38" \
+    BITNAMI_IMAGE_VERSION="8.0.28-debian-10-r39" \
     PATH="/opt/bitnami/common/bin:/opt/bitnami/mysql/bin:/opt/bitnami/mysql/sbin:$PATH"
 
 EXPOSE 3306

--- a/8.0/debian-10/Dockerfile
+++ b/8.0/debian-10/Dockerfile
@@ -21,7 +21,7 @@ RUN mkdir /docker-entrypoint-startdb.d
 COPY rootfs /
 RUN /opt/bitnami/scripts/mysql/postunpack.sh
 ENV BITNAMI_APP_NAME="mysql" \
-    BITNAMI_IMAGE_VERSION="8.0.28-debian-10-r40" \
+    BITNAMI_IMAGE_VERSION="8.0.28-debian-10-r41" \
     PATH="/opt/bitnami/common/bin:/opt/bitnami/mysql/bin:/opt/bitnami/mysql/sbin:$PATH"
 
 EXPOSE 3306

--- a/8.0/debian-10/Dockerfile
+++ b/8.0/debian-10/Dockerfile
@@ -21,7 +21,7 @@ RUN mkdir /docker-entrypoint-startdb.d
 COPY rootfs /
 RUN /opt/bitnami/scripts/mysql/postunpack.sh
 ENV BITNAMI_APP_NAME="mysql" \
-    BITNAMI_IMAGE_VERSION="8.0.28-debian-10-r37" \
+    BITNAMI_IMAGE_VERSION="8.0.28-debian-10-r38" \
     PATH="/opt/bitnami/common/bin:/opt/bitnami/mysql/bin:/opt/bitnami/mysql/sbin:$PATH"
 
 EXPOSE 3306

--- a/8.0/debian-10/rootfs/opt/bitnami/scripts/libmysql.sh
+++ b/8.0/debian-10/rootfs/opt/bitnami/scripts/libmysql.sh
@@ -331,9 +331,9 @@ EOF
 #   None
 #########################
 mysql_custom_scripts() {
-    if [[ -n $(find /docker-entrypoint-initdb.d/ -type f -regex ".*\.\(sh\|sql\|sql.gz\)") ]] && \
+    if [[ -n $(find /docker-entrypoint-$1db.d/ -type f -regex ".*\.\(sh\|sql\|sql.gz\)") ]] && \
     ([[ ! -f "$DB_DATA_DIR/.user_scripts_initialized" ]] || $1 == 'start'); then
-        info "Loading user's custom files from /docker-entrypoint-initdb.d";
+        info "Loading user's custom files from /docker-entrypoint-$1db.d";
         for f in /docker-entrypoint-$1db.d/*; do
             debug "Executing $f"
             case "$f" in
@@ -349,7 +349,7 @@ mysql_custom_scripts() {
                     fi
                     ;;
                 *.sql)
-                    [[ "$DB_REPLICATION_MODE" = "slave" ]] && warn "Custom SQL initdb is not supported on slave nodes, ignoring $f" && continue
+                    [[ "$DB_REPLICATION_MODE" = "slave" ]] && warn "Custom SQL $1db is not supported on slave nodes, ignoring $f" && continue
                     wait_for_mysql_access "$DB_ROOT_USER"
                     # Temporarily disabling autocommit to increase performance when importing huge files
                     if ! mysql_execute_print_output "$DB_DATABASE" "$DB_ROOT_USER" "$DB_ROOT_PASSWORD" <<< "SET autocommit=0; source ${f}; COMMIT;"; then
@@ -358,7 +358,7 @@ mysql_custom_scripts() {
                     fi
                     ;;
                 *.sql.gz)
-                    [[ "$DB_REPLICATION_MODE" = "slave" ]] && warn "Custom SQL initdb is not supported on slave nodes, ignoring $f" && continue
+                    [[ "$DB_REPLICATION_MODE" = "slave" ]] && warn "Custom SQL $1db is not supported on slave nodes, ignoring $f" && continue
                     wait_for_mysql_access "$DB_ROOT_USER"
                     # In this case, it is best to pipe the uncompressed SQL commands directly to the 'mysql' command as extraction may cause problems
                     # e.g. lack of disk space, permission issues...

--- a/8.0/debian-10/rootfs/opt/bitnami/scripts/libmysql.sh
+++ b/8.0/debian-10/rootfs/opt/bitnami/scripts/libmysql.sh
@@ -331,8 +331,7 @@ EOF
 #   None
 #########################
 mysql_custom_scripts() {
-    if [[ -n $(find /docker-entrypoint-$1db.d/ -type f -regex ".*\.\(sh\|sql\|sql.gz\)") ]] && \
-    ([[ ! -f "$DB_DATA_DIR/.user_scripts_initialized" ]] || $1 == 'start'); then
+    if [[ -n $(find /docker-entrypoint-"$1"db.d/ -type f -regex ".*\.\(sh\|sql\|sql.gz\)") ]] && { [[ ! -f "$DB_DATA_DIR/.user_scripts_initialized" ]] || [[ $1 = start ]]; } then
         info "Loading user's custom files from /docker-entrypoint-$1db.d";
         for f in /docker-entrypoint-$1db.d/*; do
             debug "Executing $f"

--- a/8.0/debian-10/rootfs/opt/bitnami/scripts/libmysql.sh
+++ b/8.0/debian-10/rootfs/opt/bitnami/scripts/libmysql.sh
@@ -376,6 +376,59 @@ mysql_custom_init_scripts() {
 }
 
 ########################
+# Run custom start scripts
+# Globals:
+#   DB_*
+# Arguments:
+#   None
+# Returns:
+#   None
+#########################
+mysql_custom_start_scripts() {
+    if [[ -n $(find /docker-entrypoint-startdb.d/ -type f -regex ".*\.\(sh\|sql\|sql.gz\)") ]] ; then
+        info "Loading user's custom files from /docker-entrypoint-startdb.d";
+        for f in /docker-entrypoint-startdb.d/*; do
+            debug "Executing $f"
+            case "$f" in
+                *.sh)
+                    if [[ -x "$f" ]]; then
+                        if ! "$f"; then
+                            error "Failed executing $f"
+                            return 1
+                        fi
+                    else
+                        warn "Sourcing $f as it is not executable by the current user, any error may cause initialization to fail"
+                        . "$f"
+                    fi
+                    ;;
+                *.sql)
+                    [[ "$DB_REPLICATION_MODE" = "slave" ]] && warn "Custom SQL startdb is not supported on slave nodes, ignoring $f" && continue
+                    wait_for_mysql_access "$DB_ROOT_USER"
+                    # Temporarily disabling autocommit to increase performance when importing huge files
+                    if ! mysql_execute_print_output "$DB_DATABASE" "$DB_ROOT_USER" "$DB_ROOT_PASSWORD" <<< "SET autocommit=0; source ${f}; COMMIT;"; then
+                        error "Failed executing $f"
+                        return 1
+                    fi
+                    ;;
+                *.sql.gz)
+                    [[ "$DB_REPLICATION_MODE" = "slave" ]] && warn "Custom SQL startdb is not supported on slave nodes, ignoring $f" && continue
+                    wait_for_mysql_access "$DB_ROOT_USER"
+                    # In this case, it is best to pipe the uncompressed SQL commands directly to the 'mysql' command as extraction may cause problems
+                    # e.g. lack of disk space, permission issues...
+                    if ! gunzip -c "$f" | mysql_execute_print_output "$DB_DATABASE" "$DB_ROOT_USER" "$DB_ROOT_PASSWORD"; then
+                        error "Failed executing $f"
+                        return 1
+                    fi
+                    ;;
+                *)
+                    warn "Skipping $f, supported formats are: .sh .sql .sql.gz"
+                    ;;
+            esac
+        done
+    fi
+}
+
+########################
 # Starts MySQL/MariaDB in the background and waits until it's ready
 # Globals:
 #   DB_*

--- a/8.0/debian-10/rootfs/opt/bitnami/scripts/libmysql.sh
+++ b/8.0/debian-10/rootfs/opt/bitnami/scripts/libmysql.sh
@@ -325,7 +325,7 @@ EOF
 # Run custom scripts
 # Globals:
 #   DB_*
-# Arguments: 
+# Arguments:
 #   $1 - 'init' or 'start' ('init' runs on first container start, 'start' runs everytime the container starts)
 # Returns:
 #   None

--- a/8.0/debian-10/rootfs/opt/bitnami/scripts/libmysql.sh
+++ b/8.0/debian-10/rootfs/opt/bitnami/scripts/libmysql.sh
@@ -333,7 +333,7 @@ EOF
 mysql_custom_scripts() {
     if [[ -n $(find /docker-entrypoint-"$1"db.d/ -type f -regex ".*\.\(sh\|sql\|sql.gz\)") ]] && { [[ ! -f "$DB_DATA_DIR/.user_scripts_initialized" ]] || [[ $1 = start ]]; } then
         info "Loading user's custom files from /docker-entrypoint-$1db.d";
-        for f in /docker-entrypoint-$1db.d/*; do
+        for f in /docker-entrypoint-"$1"db.d/*; do
             debug "Executing $f"
             case "$f" in
                 *.sh)

--- a/8.0/debian-10/rootfs/opt/bitnami/scripts/mysql/setup.sh
+++ b/8.0/debian-10/rootfs/opt/bitnami/scripts/mysql/setup.sh
@@ -31,6 +31,8 @@ fi
 mysql_initialize
 # Allow running custom initialization scripts
 mysql_custom_init_scripts
+# Allow running custom start scripts
+mysql_custom_start_scripts
 # Stop MySQL before flagging it as fully initialized.
 # Relying only on the trap defined above could produce a race condition.
 mysql_stop

--- a/8.0/debian-10/rootfs/opt/bitnami/scripts/mysql/setup.sh
+++ b/8.0/debian-10/rootfs/opt/bitnami/scripts/mysql/setup.sh
@@ -30,9 +30,9 @@ fi
 # Ensure MySQL is initialized
 mysql_initialize
 # Allow running custom initialization scripts
-mysql_custom_init_scripts
+mysql_custom_scripts 'init'
 # Allow running custom start scripts
-mysql_custom_start_scripts
+mysql_custom_scripts 'start'
 # Stop MySQL before flagging it as fully initialized.
 # Relying only on the trap defined above could produce a race condition.
 mysql_stop

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Non-root container images add an extra layer of security and are generally recom
 Learn more about the Bitnami tagging policy and the difference between rolling tags and immutable tags [in our documentation page](https://docs.bitnami.com/tutorials/understand-rolling-tags-containers/).
 
 
-* [`8.0`, `8.0-debian-10`, `8.0.28`, `8.0.28-debian-10-r34`, `latest` (8.0/debian-10/Dockerfile)](https://github.com/bitnami/bitnami-docker-mysql/blob/8.0.28-debian-10-r34/8.0/debian-10/Dockerfile)
+* [`8.0`, `8.0-debian-10`, `8.0.28`, `8.0.28-debian-10-r35`, `latest` (8.0/debian-10/Dockerfile)](https://github.com/bitnami/bitnami-docker-mysql/blob/8.0.28-debian-10-r35/8.0/debian-10/Dockerfile)
 * [`5.7`, `5.7-debian-10`, `5.7.37`, `5.7.37-debian-10-r50` (5.7/debian-10/Dockerfile)](https://github.com/bitnami/bitnami-docker-mysql/blob/5.7.37-debian-10-r50/5.7/debian-10/Dockerfile)
 
 Subscribe to project updates by watching the [bitnami/mysql GitHub repo](https://github.com/bitnami/bitnami-docker-mysql).

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Non-root container images add an extra layer of security and are generally recom
 Learn more about the Bitnami tagging policy and the difference between rolling tags and immutable tags [in our documentation page](https://docs.bitnami.com/tutorials/understand-rolling-tags-containers/).
 
 
-* [`8.0`, `8.0-debian-10`, `8.0.28`, `8.0.28-debian-10-r38`, `latest` (8.0/debian-10/Dockerfile)](https://github.com/bitnami/bitnami-docker-mysql/blob/8.0.28-debian-10-r38/8.0/debian-10/Dockerfile)
+* [`8.0`, `8.0-debian-10`, `8.0.28`, `8.0.28-debian-10-r39`, `latest` (8.0/debian-10/Dockerfile)](https://github.com/bitnami/bitnami-docker-mysql/blob/8.0.28-debian-10-r39/8.0/debian-10/Dockerfile)
 * [`5.7`, `5.7-debian-10`, `5.7.37`, `5.7.37-debian-10-r54` (5.7/debian-10/Dockerfile)](https://github.com/bitnami/bitnami-docker-mysql/blob/5.7.37-debian-10-r54/5.7/debian-10/Dockerfile)
 
 Subscribe to project updates by watching the [bitnami/mysql GitHub repo](https://github.com/bitnami/bitnami-docker-mysql).

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Non-root container images add an extra layer of security and are generally recom
 Learn more about the Bitnami tagging policy and the difference between rolling tags and immutable tags [in our documentation page](https://docs.bitnami.com/tutorials/understand-rolling-tags-containers/).
 
 
-* [`8.0`, `8.0-debian-10`, `8.0.28`, `8.0.28-debian-10-r35`, `latest` (8.0/debian-10/Dockerfile)](https://github.com/bitnami/bitnami-docker-mysql/blob/8.0.28-debian-10-r35/8.0/debian-10/Dockerfile)
+* [`8.0`, `8.0-debian-10`, `8.0.28`, `8.0.28-debian-10-r36`, `latest` (8.0/debian-10/Dockerfile)](https://github.com/bitnami/bitnami-docker-mysql/blob/8.0.28-debian-10-r36/8.0/debian-10/Dockerfile)
 * [`5.7`, `5.7-debian-10`, `5.7.37`, `5.7.37-debian-10-r51` (5.7/debian-10/Dockerfile)](https://github.com/bitnami/bitnami-docker-mysql/blob/5.7.37-debian-10-r51/5.7/debian-10/Dockerfile)
 
 Subscribe to project updates by watching the [bitnami/mysql GitHub repo](https://github.com/bitnami/bitnami-docker-mysql).

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Learn more about the Bitnami tagging policy and the difference between rolling t
 
 
 * [`8.0`, `8.0-debian-10`, `8.0.28`, `8.0.28-debian-10-r34`, `latest` (8.0/debian-10/Dockerfile)](https://github.com/bitnami/bitnami-docker-mysql/blob/8.0.28-debian-10-r34/8.0/debian-10/Dockerfile)
-* [`5.7`, `5.7-debian-10`, `5.7.37`, `5.7.37-debian-10-r49` (5.7/debian-10/Dockerfile)](https://github.com/bitnami/bitnami-docker-mysql/blob/5.7.37-debian-10-r49/5.7/debian-10/Dockerfile)
+* [`5.7`, `5.7-debian-10`, `5.7.37`, `5.7.37-debian-10-r50` (5.7/debian-10/Dockerfile)](https://github.com/bitnami/bitnami-docker-mysql/blob/5.7.37-debian-10-r50/5.7/debian-10/Dockerfile)
 
 Subscribe to project updates by watching the [bitnami/mysql GitHub repo](https://github.com/bitnami/bitnami-docker-mysql).
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Learn more about the Bitnami tagging policy and the difference between rolling t
 
 
 * [`8.0`, `8.0-debian-10`, `8.0.28`, `8.0.28-debian-10-r37`, `latest` (8.0/debian-10/Dockerfile)](https://github.com/bitnami/bitnami-docker-mysql/blob/8.0.28-debian-10-r37/8.0/debian-10/Dockerfile)
-* [`5.7`, `5.7-debian-10`, `5.7.37`, `5.7.37-debian-10-r52` (5.7/debian-10/Dockerfile)](https://github.com/bitnami/bitnami-docker-mysql/blob/5.7.37-debian-10-r52/5.7/debian-10/Dockerfile)
+* [`5.7`, `5.7-debian-10`, `5.7.37`, `5.7.37-debian-10-r53` (5.7/debian-10/Dockerfile)](https://github.com/bitnami/bitnami-docker-mysql/blob/5.7.37-debian-10-r53/5.7/debian-10/Dockerfile)
 
 Subscribe to project updates by watching the [bitnami/mysql GitHub repo](https://github.com/bitnami/bitnami-docker-mysql).
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Learn more about the Bitnami tagging policy and the difference between rolling t
 
 
 * [`8.0`, `8.0-debian-10`, `8.0.28`, `8.0.28-debian-10-r38`, `latest` (8.0/debian-10/Dockerfile)](https://github.com/bitnami/bitnami-docker-mysql/blob/8.0.28-debian-10-r38/8.0/debian-10/Dockerfile)
-* [`5.7`, `5.7-debian-10`, `5.7.37`, `5.7.37-debian-10-r53` (5.7/debian-10/Dockerfile)](https://github.com/bitnami/bitnami-docker-mysql/blob/5.7.37-debian-10-r53/5.7/debian-10/Dockerfile)
+* [`5.7`, `5.7-debian-10`, `5.7.37`, `5.7.37-debian-10-r54` (5.7/debian-10/Dockerfile)](https://github.com/bitnami/bitnami-docker-mysql/blob/5.7.37-debian-10-r54/5.7/debian-10/Dockerfile)
 
 Subscribe to project updates by watching the [bitnami/mysql GitHub repo](https://github.com/bitnami/bitnami-docker-mysql).
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Non-root container images add an extra layer of security and are generally recom
 Learn more about the Bitnami tagging policy and the difference between rolling tags and immutable tags [in our documentation page](https://docs.bitnami.com/tutorials/understand-rolling-tags-containers/).
 
 
-* [`8.0`, `8.0-debian-10`, `8.0.28`, `8.0.28-debian-10-r33`, `latest` (8.0/debian-10/Dockerfile)](https://github.com/bitnami/bitnami-docker-mysql/blob/8.0.28-debian-10-r33/8.0/debian-10/Dockerfile)
+* [`8.0`, `8.0-debian-10`, `8.0.28`, `8.0.28-debian-10-r34`, `latest` (8.0/debian-10/Dockerfile)](https://github.com/bitnami/bitnami-docker-mysql/blob/8.0.28-debian-10-r34/8.0/debian-10/Dockerfile)
 * [`5.7`, `5.7-debian-10`, `5.7.37`, `5.7.37-debian-10-r49` (5.7/debian-10/Dockerfile)](https://github.com/bitnami/bitnami-docker-mysql/blob/5.7.37-debian-10-r49/5.7/debian-10/Dockerfile)
 
 Subscribe to project updates by watching the [bitnami/mysql GitHub repo](https://github.com/bitnami/bitnami-docker-mysql).

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Non-root container images add an extra layer of security and are generally recom
 Learn more about the Bitnami tagging policy and the difference between rolling tags and immutable tags [in our documentation page](https://docs.bitnami.com/tutorials/understand-rolling-tags-containers/).
 
 
-* [`8.0`, `8.0-debian-10`, `8.0.28`, `8.0.28-debian-10-r39`, `latest` (8.0/debian-10/Dockerfile)](https://github.com/bitnami/bitnami-docker-mysql/blob/8.0.28-debian-10-r39/8.0/debian-10/Dockerfile)
+* [`8.0`, `8.0-debian-10`, `8.0.28`, `8.0.28-debian-10-r40`, `latest` (8.0/debian-10/Dockerfile)](https://github.com/bitnami/bitnami-docker-mysql/blob/8.0.28-debian-10-r40/8.0/debian-10/Dockerfile)
 * [`5.7`, `5.7-debian-10`, `5.7.37`, `5.7.37-debian-10-r55` (5.7/debian-10/Dockerfile)](https://github.com/bitnami/bitnami-docker-mysql/blob/5.7.37-debian-10-r55/5.7/debian-10/Dockerfile)
 
 Subscribe to project updates by watching the [bitnami/mysql GitHub repo](https://github.com/bitnami/bitnami-docker-mysql).

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Learn more about the Bitnami tagging policy and the difference between rolling t
 
 
 * [`8.0`, `8.0-debian-10`, `8.0.28`, `8.0.28-debian-10-r39`, `latest` (8.0/debian-10/Dockerfile)](https://github.com/bitnami/bitnami-docker-mysql/blob/8.0.28-debian-10-r39/8.0/debian-10/Dockerfile)
-* [`5.7`, `5.7-debian-10`, `5.7.37`, `5.7.37-debian-10-r54` (5.7/debian-10/Dockerfile)](https://github.com/bitnami/bitnami-docker-mysql/blob/5.7.37-debian-10-r54/5.7/debian-10/Dockerfile)
+* [`5.7`, `5.7-debian-10`, `5.7.37`, `5.7.37-debian-10-r55` (5.7/debian-10/Dockerfile)](https://github.com/bitnami/bitnami-docker-mysql/blob/5.7.37-debian-10-r55/5.7/debian-10/Dockerfile)
 
 Subscribe to project updates by watching the [bitnami/mysql GitHub repo](https://github.com/bitnami/bitnami-docker-mysql).
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Learn more about the Bitnami tagging policy and the difference between rolling t
 
 
 * [`8.0`, `8.0-debian-10`, `8.0.28`, `8.0.28-debian-10-r36`, `latest` (8.0/debian-10/Dockerfile)](https://github.com/bitnami/bitnami-docker-mysql/blob/8.0.28-debian-10-r36/8.0/debian-10/Dockerfile)
-* [`5.7`, `5.7-debian-10`, `5.7.37`, `5.7.37-debian-10-r51` (5.7/debian-10/Dockerfile)](https://github.com/bitnami/bitnami-docker-mysql/blob/5.7.37-debian-10-r51/5.7/debian-10/Dockerfile)
+* [`5.7`, `5.7-debian-10`, `5.7.37`, `5.7.37-debian-10-r52` (5.7/debian-10/Dockerfile)](https://github.com/bitnami/bitnami-docker-mysql/blob/5.7.37-debian-10-r52/5.7/debian-10/Dockerfile)
 
 Subscribe to project updates by watching the [bitnami/mysql GitHub repo](https://github.com/bitnami/bitnami-docker-mysql).
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Non-root container images add an extra layer of security and are generally recom
 Learn more about the Bitnami tagging policy and the difference between rolling tags and immutable tags [in our documentation page](https://docs.bitnami.com/tutorials/understand-rolling-tags-containers/).
 
 
-* [`8.0`, `8.0-debian-10`, `8.0.28`, `8.0.28-debian-10-r37`, `latest` (8.0/debian-10/Dockerfile)](https://github.com/bitnami/bitnami-docker-mysql/blob/8.0.28-debian-10-r37/8.0/debian-10/Dockerfile)
+* [`8.0`, `8.0-debian-10`, `8.0.28`, `8.0.28-debian-10-r38`, `latest` (8.0/debian-10/Dockerfile)](https://github.com/bitnami/bitnami-docker-mysql/blob/8.0.28-debian-10-r38/8.0/debian-10/Dockerfile)
 * [`5.7`, `5.7-debian-10`, `5.7.37`, `5.7.37-debian-10-r53` (5.7/debian-10/Dockerfile)](https://github.com/bitnami/bitnami-docker-mysql/blob/5.7.37-debian-10-r53/5.7/debian-10/Dockerfile)
 
 Subscribe to project updates by watching the [bitnami/mysql GitHub repo](https://github.com/bitnami/bitnami-docker-mysql).

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Non-root container images add an extra layer of security and are generally recom
 Learn more about the Bitnami tagging policy and the difference between rolling tags and immutable tags [in our documentation page](https://docs.bitnami.com/tutorials/understand-rolling-tags-containers/).
 
 
-* [`8.0`, `8.0-debian-10`, `8.0.28`, `8.0.28-debian-10-r40`, `latest` (8.0/debian-10/Dockerfile)](https://github.com/bitnami/bitnami-docker-mysql/blob/8.0.28-debian-10-r40/8.0/debian-10/Dockerfile)
+* [`8.0`, `8.0-debian-10`, `8.0.28`, `8.0.28-debian-10-r41`, `latest` (8.0/debian-10/Dockerfile)](https://github.com/bitnami/bitnami-docker-mysql/blob/8.0.28-debian-10-r41/8.0/debian-10/Dockerfile)
 * [`5.7`, `5.7-debian-10`, `5.7.37`, `5.7.37-debian-10-r56` (5.7/debian-10/Dockerfile)](https://github.com/bitnami/bitnami-docker-mysql/blob/5.7.37-debian-10-r56/5.7/debian-10/Dockerfile)
 
 Subscribe to project updates by watching the [bitnami/mysql GitHub repo](https://github.com/bitnami/bitnami-docker-mysql).

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Learn more about the Bitnami tagging policy and the difference between rolling t
 
 
 * [`8.0`, `8.0-debian-10`, `8.0.28`, `8.0.28-debian-10-r40`, `latest` (8.0/debian-10/Dockerfile)](https://github.com/bitnami/bitnami-docker-mysql/blob/8.0.28-debian-10-r40/8.0/debian-10/Dockerfile)
-* [`5.7`, `5.7-debian-10`, `5.7.37`, `5.7.37-debian-10-r55` (5.7/debian-10/Dockerfile)](https://github.com/bitnami/bitnami-docker-mysql/blob/5.7.37-debian-10-r55/5.7/debian-10/Dockerfile)
+* [`5.7`, `5.7-debian-10`, `5.7.37`, `5.7.37-debian-10-r56` (5.7/debian-10/Dockerfile)](https://github.com/bitnami/bitnami-docker-mysql/blob/5.7.37-debian-10-r56/5.7/debian-10/Dockerfile)
 
 Subscribe to project updates by watching the [bitnami/mysql GitHub repo](https://github.com/bitnami/bitnami-docker-mysql).
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Non-root container images add an extra layer of security and are generally recom
 Learn more about the Bitnami tagging policy and the difference between rolling tags and immutable tags [in our documentation page](https://docs.bitnami.com/tutorials/understand-rolling-tags-containers/).
 
 
-* [`8.0`, `8.0-debian-10`, `8.0.28`, `8.0.28-debian-10-r36`, `latest` (8.0/debian-10/Dockerfile)](https://github.com/bitnami/bitnami-docker-mysql/blob/8.0.28-debian-10-r36/8.0/debian-10/Dockerfile)
+* [`8.0`, `8.0-debian-10`, `8.0.28`, `8.0.28-debian-10-r37`, `latest` (8.0/debian-10/Dockerfile)](https://github.com/bitnami/bitnami-docker-mysql/blob/8.0.28-debian-10-r37/8.0/debian-10/Dockerfile)
 * [`5.7`, `5.7-debian-10`, `5.7.37`, `5.7.37-debian-10-r52` (5.7/debian-10/Dockerfile)](https://github.com/bitnami/bitnami-docker-mysql/blob/5.7.37-debian-10-r52/5.7/debian-10/Dockerfile)
 
 Subscribe to project updates by watching the [bitnami/mysql GitHub repo](https://github.com/bitnami/bitnami-docker-mysql).

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Learn more about the Bitnami tagging policy and the difference between rolling t
 
 
 * [`8.0`, `8.0-debian-10`, `8.0.28`, `8.0.28-debian-10-r35`, `latest` (8.0/debian-10/Dockerfile)](https://github.com/bitnami/bitnami-docker-mysql/blob/8.0.28-debian-10-r35/8.0/debian-10/Dockerfile)
-* [`5.7`, `5.7-debian-10`, `5.7.37`, `5.7.37-debian-10-r50` (5.7/debian-10/Dockerfile)](https://github.com/bitnami/bitnami-docker-mysql/blob/5.7.37-debian-10-r50/5.7/debian-10/Dockerfile)
+* [`5.7`, `5.7-debian-10`, `5.7.37`, `5.7.37-debian-10-r51` (5.7/debian-10/Dockerfile)](https://github.com/bitnami/bitnami-docker-mysql/blob/5.7.37-debian-10-r51/5.7/debian-10/Dockerfile)
 
 Subscribe to project updates by watching the [bitnami/mysql GitHub repo](https://github.com/bitnami/bitnami-docker-mysql).
 

--- a/README.md
+++ b/README.md
@@ -188,6 +188,10 @@ In order to have your custom files inside the docker image you can mount them as
 Take into account those scripts are treated differently depending on the extension. While the `.sh` scripts are executed in all the nodes; the `.sql` and `.sql.gz` scripts are only executed in the master nodes. The reason behind this differentiation is that the `.sh` scripts allow adding conditions to determine what is the node running the script, while these conditions can't be set using `.sql` nor `sql.gz` files. This way it is possible to cover different use cases depending on their needs.
 
 > NOTE: If you are importing large databases, it is recommended to import them as `.sql` instead of `.sql.gz`, as the latter one needs to be decompressed on the fly and not allowing for additional optimizations to import large files.
+> 
+### Running scripts on start
+
+Same semantics as [Initializing a new instance](#initializing-a-new-instance), except these scripts will always run (after /docker-entrypoint-initdb.d/ scripts, if they exist.) The file directory to place your start scripts is: `/docker-entrypoint-startdb.d`.
 
 ### Setting the root password on first run
 

--- a/README.md
+++ b/README.md
@@ -188,10 +188,10 @@ In order to have your custom files inside the docker image you can mount them as
 Take into account those scripts are treated differently depending on the extension. While the `.sh` scripts are executed in all the nodes; the `.sql` and `.sql.gz` scripts are only executed in the master nodes. The reason behind this differentiation is that the `.sh` scripts allow adding conditions to determine what is the node running the script, while these conditions can't be set using `.sql` nor `sql.gz` files. This way it is possible to cover different use cases depending on their needs.
 
 > NOTE: If you are importing large databases, it is recommended to import them as `.sql` instead of `.sql.gz`, as the latter one needs to be decompressed on the fly and not allowing for additional optimizations to import large files.
-> 
+
 ### Running scripts on start
 
-Same semantics as [Initializing a new instance](#initializing-a-new-instance), except these scripts will always run (after /docker-entrypoint-initdb.d/ scripts, if they exist.) The file directory to place your start scripts is: `/docker-entrypoint-startdb.d`.
+Same semantics as [Initializing a new instance](#initializing-a-new-instance), except these scripts will always run (after `/docker-entrypoint-initdb.d/` scripts, if they exist.) The file directory to place your start scripts is: `/docker-entrypoint-startdb.d`.
 
 ### Setting the root password on first run
 


### PR DESCRIPTION
**Description of the change**

Much like the docker-entrypoint-initdb.d functionality that runs scripts on database initialization, this PR will introduce functionality that will allow developers to run scripts on database start.  The functionality is pretty much identical.

**Benefits**

This will allow developers to deploy idempotent scripts and have these changes applied to an existing database.

**Possible drawbacks**

The start scripts must be idempotent, otherwise, an existing database could end up in a bad state.

**Applicable issues**

Issue #143 

**Additional information**
N/A
